### PR TITLE
optional rounding of calibration results

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,8 +13,8 @@ The units in Signal K are SI units, so for example angles are in radians.
 ![image](https://user-images.githubusercontent.com/1049678/100268587-ef688300-2f5d-11eb-9b5e-4358af94d110.png)
 
 Build instructions:
-git clone git@github.com:SignalK/calibration.git
+```git clone git@github.com:SignalK/calibration.git
 cd calibration
 npm install && npm run build
-npm run dev
+npm run dev```
 

--- a/README.md
+++ b/README.md
@@ -12,6 +12,9 @@ The units in Signal K are SI units, so for example angles are in radians.
 
 ![image](https://user-images.githubusercontent.com/1049678/100268587-ef688300-2f5d-11eb-9b5e-4358af94d110.png)
 
-
-
+Build instructions:
+git clone git@github.com:SignalK/calibration.git
+cd calibration
+npm install && npm run build
+npm run dev
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,8 @@ The units in Signal K are SI units, so for example angles are in radians.
 ![image](https://user-images.githubusercontent.com/1049678/100268587-ef688300-2f5d-11eb-9b5e-4358af94d110.png)
 
 Build instructions:
-```git clone git@github.com:SignalK/calibration.git
+```
+git clone git@github.com:SignalK/calibration.git
 cd calibration
 npm install && npm run build
 npm run dev```

--- a/index.js
+++ b/index.js
@@ -37,7 +37,8 @@ module.exports = function (app) {
           calibration.mappings.sort((a, b) => a.in - b.in)
 
           const period = parseFloat(calibration.period)
-          debug(`path:${calibration.path} sourceRef:${calibration.sourceRef} period:${calibration.period}`)
+          const decimals = parseInt(calibration.decimals)
+          debug(`path:${calibration.path} sourceRef:${calibration.sourceRef} decimals: ${calibration.decimals}, period:${calibration.period}`)
 
           let previousOut = Number.MIN_VALUE
           const convert = linearInterpolator(
@@ -68,12 +69,16 @@ module.exports = function (app) {
                         if (!isNaN(period)) {
                           result = (result / period) % 1 * period
                         }
+                        let calibrated = result
+                        if (!isNaN(decimals)){
+                          result = parseFloat(result.toFixed(decimals))
+                        }
                         lastConversions[calibration.path] = {
                           in: pathValue.value,
                           out: result
                         }
                         if (debug.enabled) {
-                          debug(`${pathValue.path}(${update.$source}) ${pathValue.value} => ${result})`)
+                          debug(`${pathValue.path}(${update.$source}) ${pathValue.value} => ${result} (${calibrated}))`)
                         }
                         pathValue.value = result
                       }
@@ -115,6 +120,9 @@ module.exports = function (app) {
             },
             sourceRef: {
               type: 'string'
+            },
+            decimals: {
+              type: 'number'
             },
             period: {
               type: 'number'

--- a/src/components/PluginConfigurationPanel.js
+++ b/src/components/PluginConfigurationPanel.js
@@ -10,6 +10,7 @@ export default (props) => {
   calibrationsToRender.push({
     path: '',
     sourceRef: '',
+    decimals: '',
     period: '',
     mappings: []
   })
@@ -41,6 +42,7 @@ const labelStyle = {
 const Calibration = (props) => {
   const [path, setPath] = useState(props.path)
   const [sourceRef, setSourceRef] = useState(props.sourceRef)
+  const [decimals, setDecimals] = useState(props.decimals)
   const [period, setPeriod] = useState(props.period)
   const [mappings, setMappings] = useState(props.mappings)
 
@@ -64,6 +66,12 @@ const Calibration = (props) => {
                 setter={setSourceRef}
                 text='Specify source if needed, leave empty otherwise. Sources are available in Data Browser.' />
               <FormField
+                fieldName='decimals'
+                label='Decimals'
+                value={decimals}
+                setter={setDecimals}
+                text='Specify number of decimals if you want the results to be rounded, leave empty otherwise.' />
+              <FormField
                 fieldName='period'
                 label='Period'
                 value={period}
@@ -83,6 +91,7 @@ const Calibration = (props) => {
                         props.save({
                           path,
                           sourceRef,
+                          decimals,
                           period,
                           mappings
                         })


### PR DESCRIPTION
This PR adds an option to have calibration results rounded before being sent to SK. 
If no decimals are defined, the plugin will work as ever.
See screenshot and test debug ouputs (converting kWh to Ah@12V)

---

Tests:

**config JSON:**
decimals entry missing (undefined), legacy: OK (same results as before)
decimals entry empty (NUL): OK (same results as before)
decimals entry valid: OK

2021-05-22T16:31:48.346Z @signalk/calibration path:sensors.PZEM.total sourceRef:mqtt.PZEM decimals: 3 period:
2021-05-22T16:31:48.357Z @signalk/calibration path:sensors.PZEM.today sourceRef:mqtt.PZEM decimals: period:
2021-05-22T16:31:48.358Z @signalk/calibration path:sensors.PZEM.yesterday sourceRef:mqtt.PZEM decimals: undefined period:
...
2021-05-26T10:39:10.548Z @signalk/calibration path:sensors.PZEM.total sourceRef:mqtt.PZEM decimals: 3, period:
2021-05-26T10:39:10.559Z @signalk/calibration path:sensors.PZEM.today sourceRef:mqtt.PZEM decimals: 2, period:
2021-05-26T10:39:10.560Z @signalk/calibration path:sensors.PZEM.yesterday sourceRef:mqtt.PZEM decimals: 1, period:
...
2021-05-26T10:44:16.435Z @signalk/calibration sensors.PZEM.yesterday(mqtt.PZEM) 0.148 => 8.7 (8.693636363636363))
2021-05-26T10:44:17.038Z @signalk/calibration sensors.PZEM.total(mqtt.PZEM) 4.895 => 407.913 (407.91333333333324))
2021-05-26T10:44:45.863Z @signalk/calibration sensors.PZEM.today(mqtt.PZEM) 0.083 => 6.91 (6.9139))

**plugin config UI:**
decimals entry invalid: 
NaN: OK (same results as before)
entry with fraction: entry gets truncated and processed
negative: throws range error exception in SK-log, (garbage in -> garbage out)
<img width="422" alt="CAPT-20210526-124843" src="https://user-images.githubusercontent.com/18160302/119650948-b9309100-be24-11eb-86b2-fd820e91cd7d.png">`
